### PR TITLE
Doubleclick integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,20 @@
-# mParticle JS Example Web Integration
+DoubleClick Integration
+===========================
 
-A web integration (or a kit) is an extension to the core [mParticle Web SDK](https://github.com/mParticle/mparticle-javascript-sdk). A kit works as a bridge between the mParticle SDK and a partner SDK. It abstracts the implementation complexity, simplifying the implementation for developers.
+DoubleClick Javascript integration for mParticle
 
-A kit takes care of initializing and forwarding information depending on what you've configured in [mParticle's dashboard](https://app.mparticle.com).
+# License
 
-## Create Your Own Integration
+Copyright 2019 mParticle, Inc.
 
-Detailed instructions on how to implement your own integration with the mParticle Web SDK can be found [here](https://docs.mparticle.com/developers/partners/kit-integrations/javascript-kit), but you can view a quick start guide below.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-## Quick Start Guide
+http://www.apache.org/licenses/LICENSE-2.0
 
-1. Fork this repo and `cd` into it locally on your computer.
-2. Run `npm install` to install dependencies.
-3. Run `KIT=YOURKITNAME npm run watch` to watch files in the `src/` folder, and automatically build your kit to `build/YOURKITNAME-Kit.js`. Your kit will continuously build as your save your edits.
-4. Following examples such as [Optimizely](http://https://github.com/mparticle-integrations/mparticle-javascript-integration-optimizely), edit files in `src/`.
-5. As you map mParticle's methods to your own in `src/`, stub your SDK methods and create tests in `test/tests.js`.
-6. Submit a pull request to this repo. A developer from mParticle will review it and once complete, we will help provide you with a repo for your integration.
-
-## Support
-
-Questions? Give us a shout at <support@mparticle.com>
-
-## License
-
-This mParticle Web Kit is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). See the LICENSE file for more info.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build/DoubleClick-Kit.js
+++ b/build/DoubleClick-Kit.js
@@ -323,7 +323,13 @@ var commerceHandler = {
             }
 
             var eventMapping = common.getEventMapping(event);
-            if (eventMapping && eventMapping.result && eventMapping.match) {
+
+            if (!eventMapping) {
+                console.log('Event not mapped. Event not sent.');
+                return false;
+            }
+
+            if (eventMapping.result && eventMapping.match) {
                 var gtagProperties = {};
                 common.setCustomVariables(event, gtagProperties);
                 common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
@@ -336,9 +342,7 @@ var commerceHandler = {
                     gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
                 }
                 common.sendGtag('purchase', gtagProperties);
-            } else {
-                console.log('Event not mapped. Event not sent.');
-                return false;
+                return true;
             }
         }
     }
@@ -432,17 +436,16 @@ var eventHandler = {
 
         if (eventMapping.result && eventMapping.match) {
             var counter = event.CustomFlags && event.CustomFlags['DoubleClick.Counter'] ? event.CustomFlags['DoubleClick.Counter'] : null;
-            if (counter) {
-                if (eventCounterTypes[counter]) {
-                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
-                    gtagProperties.send_to += ('+' + counter);
-                    common.sendGtag('conversion', gtagProperties);
-                } else {
-                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                    return false;
-                }
-            } else {
+            if (!counter) {
                 console.log('Event not sent. Event conversions requires a custom flag of DoubleClick.Counter equal to \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                return false;
+            }
+            if (eventCounterTypes[counter]) {
+                common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                gtagProperties.send_to += ('+' + counter);
+                common.sendGtag('conversion', gtagProperties);
+            } else {
+                console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
                 return false;
             }
         }

--- a/build/DoubleClick-Kit.js
+++ b/build/DoubleClick-Kit.js
@@ -1,0 +1,589 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+// =============== REACH OUT TO MPARTICLE IF YOU HAVE ANY QUESTIONS ===============
+//
+//  Copyright 2018 mParticle, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+var CommerceHandler = require('../../../src/commerce-handler');
+var EventHandler = require('../../../src/event-handler');
+var IdentityHandler = require('../../../src/identity-handler');
+var Initialization = require('../../../src/initialization');
+var SessionHandler = require('../../../src/session-handler');
+var UserAttributeHandler = require('../../../src/user-attribute-handler');
+
+(function (window) {
+    var name = Initialization.name,
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd: 2,
+            PageView: 3,
+            PageEvent: 4,
+            CrashReport: 5,
+            OptOut: 6,
+            Commerce: 16
+        };
+
+    var constructor = function () {
+        var self = this,
+            isInitialized = false,
+            forwarderSettings,
+            reportingService,
+            eventQueue = [];
+
+        self.name = Initialization.name;
+
+        function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities) {
+            forwarderSettings = settings;
+            if (window.mParticle.isTestEnvironment) {
+                reportingService = function() {
+                };
+            } else {
+                reportingService = service;
+            }
+
+            try {
+                Initialization.initForwarder(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized);
+                isInitialized = true;
+            } catch (e) {
+                console.log('Failed to initialize ' + name + ' - ' + e);
+            }
+        }
+
+        function processEvent(event) {
+            var reportEvent = false;
+            if (isInitialized) {
+                try {
+                    if (event.EventDataType === MessageType.SessionStart) {
+                        reportEvent = logSessionStart(event);
+                    } else if (event.EventDataType === MessageType.SessionEnd) {
+                        reportEvent = logSessionEnd(event);
+                    } else if (event.EventDataType === MessageType.CrashReport) {
+                        reportEvent = logError(event);
+                    } else if (event.EventDataType === MessageType.PageView) {
+                        reportEvent = logPageView(event);
+                    }
+                    else if (event.EventDataType === MessageType.Commerce) {
+                        reportEvent = logEcommerceEvent(event);
+                    }
+                    else if (event.EventDataType === MessageType.PageEvent) {
+                        reportEvent = logEvent(event);
+                    }
+                    if (reportEvent === true && reportingService) {
+                        reportingService(self, event);
+                        return 'Successfully sent to ' + name;
+                    }
+                    else {
+                        return 'Error logging event or event type not supported on forwarder ' + name;
+                    }
+                }
+                catch (e) {
+                    return 'Failed to send to ' + name + ' ' + e;
+                }
+            } else {
+                eventQueue.push(event);
+                return 'Can\'t send to forwarder ' + name + ', not initialized. Event added to queue.';
+            }
+        }
+
+        function logSessionStart(event) {
+            try {
+                SessionHandler.onSessionStart(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error starting session on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function logSessionEnd(event) {
+            try {
+                SessionHandler.onSessionEnd(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error ending session on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function logError(event) {
+            try {
+                EventHandler.logError(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error logging error on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function logPageView(event) {
+            try {
+                EventHandler.logPageView(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error logging page view on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function logEvent(event) {
+            try {
+                EventHandler.logEvent(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error logging event on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function logEcommerceEvent(event) {
+            try {
+                CommerceHandler.logCommerceEvent(event);
+                return true;
+            } catch (e) {
+                return {error: 'Error logging purchase event on forwarder ' + name + '; ' + e};
+            }
+        }
+
+        function setUserAttribute(key, value) {
+            if (isInitialized) {
+                try {
+                    UserAttributeHandler.onSetUserAttribute(key, value, forwarderSettings);
+                    return 'Successfully set user attribute on forwarder ' + name;
+                } catch (e) {
+                    return 'Error setting user attribute on forwarder ' + name + '; ' + e;
+                }
+            } else {
+                return 'Can\'t set user attribute on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function removeUserAttribute(key) {
+            if (isInitialized) {
+                try {
+                    UserAttributeHandler.onRemoveUserAttribute(key, forwarderSettings);
+                    return 'Successfully removed user attribute on forwarder ' + name;
+                } catch (e) {
+                    return 'Error removing user attribute on forwarder ' + name + '; ' + e;
+                }
+            } else {
+                return 'Can\'t remove user attribute on forwarder ' + name + ', not initialized';
+            }
+        }
+
+        function setUserIdentity(id, type) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onSetUserIdentity(forwarderSettings, id, type);
+                    return 'Successfully set user Identity on forwarder ' + name;
+                } catch (e) {
+                    return 'Error removing user attribute on forwarder ' + name + '; ' + e;
+                }
+            } else {
+                return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+            }
+
+        }
+
+        function onUserIdentified(user) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onUserIdentified(user);
+
+                    return 'Successfully called onUserIdentified on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling onUserIdentified on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t set new user identities on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        function onIdentifyComplete(user, filteredIdentityRequest) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onIdentifyCompleted(user, filteredIdentityRequest);
+
+                    return 'Successfully called onIdentifyCompleted on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling onIdentifyCompleted on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t call onIdentifyCompleted on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        function onLoginComplete(user, filteredIdentityRequest) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onLoginComplete(user, filteredIdentityRequest);
+
+                    return 'Successfully called onLoginComplete on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling onLoginComplete on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t call onLoginComplete on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        function onLogoutComplete(user, filteredIdentityRequest) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onLogoutComplete(user, filteredIdentityRequest);
+
+                    return 'Successfully called onLogoutComplete on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling onLogoutComplete on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t call onLogoutComplete on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        function onModifyComplete(user, filteredIdentityRequest) {
+            if (isInitialized) {
+                try {
+                    IdentityHandler.onModifyComplete(user, filteredIdentityRequest);
+
+                    return 'Successfully called onModifyComplete on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling onModifyComplete on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t call onModifyComplete on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        function setOptOut(isOptingOutBoolean) {
+            if (isInitialized) {
+                try {
+                    Initialization.setOptOut(isOptingOutBoolean);
+
+                    return 'Successfully called setOptOut on forwarder ' + name;
+                } catch (e) {
+                    return {error: 'Error calling setOptOut on forwarder ' + name + '; ' + e};
+                }
+            }
+            else {
+                return 'Can\'t call setOptOut on forwader  ' + name + ', not initialized';
+            }
+        }
+
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserAttribute = setUserAttribute;
+        this.removeUserAttribute = removeUserAttribute;
+        this.onUserIdentified = onUserIdentified;
+        this.setUserIdentity = setUserIdentity;
+        this.onIdentifyComplete = onIdentifyComplete;
+        this.onLoginComplete = onLoginComplete;
+        this.onLogoutComplete = onLogoutComplete;
+        this.onModifyComplete = onModifyComplete;
+        this.setOptOut = setOptOut;
+    };
+
+    if (!window || !window.mParticle || !window.mParticle.addForwarder) {
+        return;
+    }
+
+    window.mParticle.addForwarder({
+        name: name,
+        constructor: constructor
+    });
+})(window);
+
+},{"../../../src/commerce-handler":2,"../../../src/event-handler":4,"../../../src/identity-handler":5,"../../../src/initialization":6,"../../../src/session-handler":7,"../../../src/user-attribute-handler":8}],2:[function(require,module,exports){
+var common = require('./common'),
+    TRANSACTIONS = 'transactions',
+    ITEMS_SOLD = 'items_sold';
+
+var commerceHandler = {
+    logCommerceEvent: function(event) {
+        if (event.EventDataType === 16) {
+            var eventMapping = common.getEventMapping(event);
+            if (eventMapping && eventMapping.result && eventMapping.match) {
+                var gtagProperties = {};
+                common.setCustomVariables(event, gtagProperties);
+                common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
+                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                    //stringify number
+                    gtagProperties.value = '' + event.ProductAction.TotalAmount;
+                    gtagProperties.transaction_id = event.ProductAction.TransactionId;
+
+                    if (event.CustomFlags['DoubleClick.Counter'] === TRANSACTIONS) {
+                        common.sendGtag('purchase', gtagProperties);
+                    } else if (event.CustomFlags['DoubleClick.Counter'] === ITEMS_SOLD) {
+                        //stringify number
+                        gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
+
+                        common.sendGtag('purchase', gtagProperties);
+                    } else {
+                        console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                        return false;
+                    }
+                } else {
+                    console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                    return false;
+                }
+                window.gtag('event', 'purchase', gtagProperties);
+            } else {
+                console.log('Event not mapped. Event not sent.');
+                return false;
+            }
+        }
+    }
+};
+
+module.exports = commerceHandler;
+
+},{"./common":3}],3:[function(require,module,exports){
+module.exports = {
+    eventMapping: {},
+    customVariablesMappings: {},
+    settings: {},
+    setCustomVariables: function(event, gtagProperties) {
+        for (var attribute in event.EventAttributes) {
+            if (this.customVariablesMappings[attribute]) {
+                gtagProperties[this.customVariablesMappings[attribute]] = event.EventAttributes[attribute];
+            }
+        }
+    },
+    setSendTo: function(mapping, customFlags, gtagProperties) {
+        var tags = mapping.value.split(';');
+        var groupTag = tags[0];
+        var activityTag = tags[1];
+        gtagProperties.send_to = 'DC-' + this.settings.advertiserId + '/' + groupTag + '/' + activityTag;
+    },
+    getEventMapping: function (event) {
+        var jsHash = calculateJSHash(event.EventDataType, event.EventCategory, event.EventName);
+        return findValueInMapping(jsHash, this.eventMapping);
+    },
+    sendGtag: function(type, properties) {
+        window.gtag('event', type, properties);
+    }
+};
+
+function findValueInMapping(jsHash, mapping) {
+    if (mapping) {
+        var filteredArray = mapping.filter(function(mappingEntry) {
+            if (mappingEntry.jsmap && mappingEntry.maptype && mappingEntry.value) {
+                return mappingEntry.jsmap === jsHash.toString();
+            }
+
+            return {
+                result: false
+            };
+        });
+
+        if (filteredArray && filteredArray.length > 0) {
+            return {
+                result: true,
+                match: filteredArray[0]
+            };
+        }
+    }
+    return null;
+}
+
+function calculateJSHash(eventDataType, eventCategory, name) {
+    var preHash =
+        ('' + eventDataType) +
+        ('' + eventCategory) + '' +
+        (name || '');
+
+    return mParticle.generateHash(preHash);
+}
+
+},{}],4:[function(require,module,exports){
+var common = require('./common');
+
+var eventCounterTypes = {
+    standard: 1,
+    unique: 1,
+    per_session: 1
+};
+
+var eventHandler = {
+    logEvent: function(event) {
+        var gtagProperties = {};
+        common.setCustomVariables(event, gtagProperties);
+        var eventMapping = common.getEventMapping(event);
+        if (eventMapping && eventMapping.result && eventMapping.match) {
+            if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
+                if (eventCounterTypes[event.CustomFlags['DoubleClick.Counter']]) {
+                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                    common.sendGtag('conversion', gtagProperties);
+                } else {
+                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                }
+            } else {
+                console.log('event not sent, no counter set. Please set a customFlag of DoubleClick.Counter');
+                return false;
+            }
+        } else {
+            console.log('Event not mapped. Event not sent.');
+            return false;
+        }
+    },
+    logError: function() {
+    },
+    logPageView: function() {
+    }
+};
+
+module.exports = eventHandler;
+
+},{"./common":3}],5:[function(require,module,exports){
+/*
+The 'mParticleUser' is an object with methods get user Identities and set/get user attributes
+Partners can determine what userIds are available to use in their SDK
+Call mParticleUser.getUserIdentities() to return an object of userIdentities --> { userIdentities: {customerid: '1234', email: 'email@gmail.com'} }
+For more identity types, see http://docs.mparticle.com/developers/sdk/javascript/identity#allowed-identity-types
+Call mParticleUser.getMPID() to get mParticle ID
+For any additional methods, see http://docs.mparticle.com/developers/sdk/javascript/apidocs/classes/mParticle.Identity.getCurrentUser().html
+*/
+
+
+/*
+identityApiRequest has the schema:
+{
+  userIdentities: {
+    customerid: '123',
+    email: 'abc'
+  }
+}
+For more userIdentity types, see http://docs.mparticle.com/developers/sdk/javascript/identity#allowed-identity-types
+*/
+
+var identityHandler = {
+    onUserIdentified: function(mParticleUser) {
+
+    },
+    onIdentifyCompleted: function(mParticleUser, identityApiRequest) {
+
+    },
+    onLoginCompleted: function(mParticleUser, identityApiRequest) {
+
+    },
+    onLogoutCompleted: function(mParticleUser, identityApiRequest) {
+
+    },
+    onModifyCompleted: function(mParticleUser, identityApiRequest) {
+
+    },
+
+/*  In previous versions of the mParticle web SDK, setting user identities on
+    kits is only reachable via the onSetUserIdentity method below. We recommend
+    filling out `onSetUserIdentity` for maximum compatibility
+*/
+    onSetUserIdentity: function(forwarderSettings, id, type) {
+
+    }
+};
+
+module.exports = identityHandler;
+
+},{}],6:[function(require,module,exports){
+var common = require('./common');
+
+var initialization = {
+    name: 'DoubleclickDFP',
+    initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
+        common.settings = settings;
+        window.gtag = function() {
+            window.dataLayer.push(arguments);
+        };
+
+        window.dataLayer = window.dataLayer || [];
+        if (!testMode) {
+            var url = 'https://www.googletagmanager.com/gtag/js?id=' + settings.advertiserId;
+
+            var gTagScript = document.createElement('script');
+            gTagScript.type = 'text/javascript';
+            gTagScript.async = true;
+            gTagScript.src = url;
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(gTagScript);
+            gTagScript.onload = function() {
+                isInitialized = true;
+
+                initializeGoogleDFP(settings);
+
+                if (window.gtag && eventQueue.length > 0) {
+                    // Process any events that may have been queued up while forwarder was being initialized.
+                    for (var i = 0; i < eventQueue.length; i++) {
+                        processEvent(eventQueue[i]);
+                    }
+                     // now that each queued event is processed, we empty the eventQueue
+                    eventQueue = [];
+                }
+            };
+        } else {
+            isInitialized = true;
+            initializeGoogleDFP(settings);
+        }
+    }
+};
+
+function initializeGoogleDFP(settings) {
+    common.eventMapping = JSON.parse(settings.eventMapping.replace(/&quot;/g, '\"'));
+
+    common.customVariablesMappings = JSON.parse(settings.customVariables.replace(/&quot;/g, '\"')).reduce(function(a, b) {
+        a[b.map] = b.value;
+        return a;
+    }, {});
+    window.gtag('js', new Date());
+    window.gtag('allow_custom_scripts', true);
+    window.gtag('config', settings.advertiserId);
+}
+
+module.exports = initialization;
+
+},{"./common":3}],7:[function(require,module,exports){
+var sessionHandler = {
+    onSessionStart: function(event) {
+        
+    },
+    onSessionEnd: function(event) {
+
+    }
+};
+
+module.exports = sessionHandler;
+
+},{}],8:[function(require,module,exports){
+/*
+The 'mParticleUser' is an object with methods on it to get user Identities and set/get user attributes
+Partners can determine what userIds are available to use in their SDK
+Call mParticleUser.getUserIdentities() to return an object of userIdentities --> { userIdentities: {customerid: '1234', email: 'email@gmail.com'} }
+For more identity types, see http://docs.mparticle.com/developers/sdk/javascript/identity#allowed-identity-types
+Call mParticleUser.getMPID() to get mParticle ID
+For any additional methods, see http://docs.mparticle.com/developers/sdk/javascript/apidocs/classes/mParticle.Identity.getCurrentUser().html
+*/
+
+var userAttributeHandler = {
+    onRemoveUserAttribute: function(key, mParticleUser) {
+
+    },
+    onSetUserAttribute: function(key, value, mParticleUser) {
+
+    },
+    onConsentStateUpdated: function(oldState, newState, mParticleUser) {
+
+    }
+};
+
+module.exports = userAttributeHandler;
+
+},{}]},{},[1]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,13 @@
   "requires": true,
   "dependencies": {
     "@mparticle/web-kit-wrapper": {
-      "version": "1.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/@mparticle/web-kit-wrapper/-/web-kit-wrapper-1.0.0-rc3.tgz",
-      "integrity": "sha512-awtuwUSA7KYrrW32ypTLWQHt49BEPv+Sl0wM6vKMQGkyaeGwc0FQdLA6zZsFBmbb2y5GRrKXh4G58ZJ3b9rtRw==",
-      "dev": true
+      "version": "1.0.0-rc5",
+      "resolved": "https://registry.npmjs.org/@mparticle/web-kit-wrapper/-/web-kit-wrapper-1.0.0-rc5.tgz",
+      "integrity": "sha512-dkeYKEwPOisFRqAyf1IkFHo/c2PURXcIITEd/TZv4fC3zfsfY0ZhUoEuSSThgW1RNUQoCVy3c7B4DmzrpccBRg==",
+      "dev": true,
+      "requires": {
+        "express": "^4.16.4"
+      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -98,6 +101,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-map": {
@@ -821,6 +830,12 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -837,6 +852,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-descriptor": {
@@ -1030,6 +1051,12 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
     "detective": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
@@ -1218,6 +1245,12 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -1323,6 +1356,67 @@
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
           "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+          "dev": true
+        }
+      }
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "finalhandler": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -1506,6 +1600,12 @@
         "for-in": "^1.0.1"
       }
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1514,6 +1614,12 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs-access": {
       "version": "1.0.1",
@@ -2386,6 +2492,12 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -2814,6 +2926,18 @@
       "version": "0.3.0",
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
@@ -3281,6 +3405,12 @@
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -3323,6 +3453,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      }
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -3578,6 +3718,53 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -3651,38 +3838,57 @@
       }
     },
     "should": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
-      "integrity": "sha1-ZGTEi298Hh8YrASDV4+i3VXCxuA=",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
-        "should-equal": "0.5.0",
-        "should-format": "0.3.1",
-        "should-type": "0.2.0"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
-      "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
-      "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
-        "should-type": "0.2.0"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.1.tgz",
-      "integrity": "sha1-LLt4JGFnCs5CkrKx7EaNuM+Z4zA=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "dev": true,
       "requires": {
-        "should-type": "0.2.0"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
-      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
       "dev": true
     },
     "simple-concat": {
@@ -4359,6 +4565,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "testEndToEnd": "browserify node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js -v -o test/end-to-end-testapp/build/compilation.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
   },
   "devDependencies": {
-    "@mparticle/web-kit-wrapper": "^1.0.0-rc4",
+    "@mparticle/web-kit-wrapper": "^1.0.0-rc5",
     "mocha": "^5.2.0",
     "chai": "^4.2.0",
     "karma": "^3.1.1",

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -1,63 +1,42 @@
+var common = require('./common'),
+    TRANSACTIONS = 'transactions',
+    ITEMS_SOLD = 'items_sold';
+
 var commerceHandler = {
     logCommerceEvent: function(event) {
-        /*
-        Sample ecommerce event schema:
-        {
-            CurrencyCode: 'USD',
-            DeviceId:'a80eea1c-57f5-4f84-815e-06fe971b6ef2', // MP generated
-            EventAttributes: { key1: 'value1', key2: 'value2' },
-            EventType: 16,
-            EventCategory: 10, // (This is an add product to cart event, see below for additional ecommerce EventCategories)
-            EventName: "eCommerce - AddToCart",
-            MPID: "8278431810143183490",
-            ProductAction: {
-                Affiliation: 'aff1',
-                CouponCode: 'coupon',
-                ProductActionType: 7,
-                ProductList: [
-                    {
-                        Attributes: { prodKey1: 'prodValue1', prodKey2: 'prodValue2' },
-                        Brand: 'Apple',
-                        Category: 'phones',
-                        CouponCode: 'coupon1',
-                        Name: 'iPhone',
-                        Price: '600',
-                        Quantity: 2,
-                        Sku: "SKU123",
-                        TotalAmount: 1200,
-                        Variant: '64GB'
+        if (event.EventDataType === 16) {
+            var eventMapping = common.getEventMapping(event);
+            if (eventMapping && eventMapping.result && eventMapping.match) {
+                var gtagProperties = {};
+                common.setCustomVariables(event, gtagProperties);
+                common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
+                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                    //stringify number
+                    gtagProperties.value = '' + event.ProductAction.TotalAmount;
+                    gtagProperties.transaction_id = event.ProductAction.TransactionId;
+
+                    if (event.CustomFlags['DoubleClick.Counter'] === TRANSACTIONS) {
+                        common.sendGtag('purchase', gtagProperties);
+                    } else if (event.CustomFlags['DoubleClick.Counter'] === ITEMS_SOLD) {
+                        //stringify number
+                        gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
+
+                        common.sendGtag('purchase', gtagProperties);
+                    } else {
+                        console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                        return false;
                     }
-                ],
-                TransactionId: "tid1",
-                ShippingAmount: 10,
-                TaxAmount: 5,
-                TotalAmount: 1215,
-            },
-            UserAttributes: { userKey1: 'userValue1', userKey2: 'userValue2' }
-            UserIdentities: [
-                {
-                    Identity: 'test@gmail.com', Type: 7
+                } else {
+                    console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                    return false;
                 }
-            ]
+                window.gtag('event', 'purchase', gtagProperties);
+            } else {
+                console.log('Event not mapped. Event not sent.');
+                return false;
+            }
         }
-
-        If your SDK has specific ways to log different eCommerce events, see below for
-        mParticle's additional ecommerce EventCategory types:
-
-            10: ProductAddToCart, (as shown above)
-            11: ProductRemoveFromCart,
-            12: ProductCheckout,
-            13: ProductCheckoutOption,
-            14: ProductClick,
-            15: ProductViewDetail,
-            16: ProductPurchase,
-            17: ProductRefund,
-            18: PromotionView,
-            19: PromotionClick,
-            20: ProductAddToWishlist,
-            21: ProductRemoveFromWishlist,
-            22: ProductImpression
-        */
     }
 };
 

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -4,7 +4,7 @@ var common = require('./common'),
 
 var commerceHandler = {
     logCommerceEvent: function(event) {
-        if (event.EventDataType === 16) {
+        if (event.EventDataType === mParticle.CommerceEventType.ProductPurchase) {
             var eventMapping = common.getEventMapping(event);
             if (eventMapping && eventMapping.result && eventMapping.match) {
                 var gtagProperties = {};
@@ -31,7 +31,7 @@ var commerceHandler = {
                     console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
                     return false;
                 }
-                window.gtag('event', 'purchase', gtagProperties);
+                common.gtag('event', 'purchase', gtagProperties);
             } else {
                 console.log('Event not mapped. Event not sent.');
                 return false;

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -31,6 +31,7 @@ var commerceHandler = {
                     gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
                 }
                 common.sendGtag('purchase', gtagProperties);
+                return true;
             } else {
                 console.log('Event not mapped. Event not sent.');
                 return false;

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -8,13 +8,13 @@ var common = require('./common'),
 var commerceHandler = {
     logCommerceEvent: function(event) {
         if (event.EventDataType === mParticle.CommerceEventType.ProductPurchase) {
-            var counter = event.CustomFlags['DoubleClick.Counter'];
+            var counter = event.CustomFlags && event.CustomFlags['DoubleClick.Counter'] ? event.CustomFlags['DoubleClick.Counter'] : null;
             if (!counter) {
                 console.log('Event not sent. Sales conversions requires a custom flag of DoubleClick.Counter equal to \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                return;
+                return false;
             } else if (!salesCounterTypes[counter]) {
                 console.log('Counter type not valid. For sales conversions, use a custom flag of DoubleClick.Counter equal to \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                return;
+                return false;
             }
 
             var eventMapping = common.getEventMapping(event);
@@ -22,7 +22,7 @@ var commerceHandler = {
                 var gtagProperties = {};
                 common.setCustomVariables(event, gtagProperties);
                 common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
-                gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                gtagProperties.send_to += ('+' + counter);
                 //stringify number
                 gtagProperties.value = '' + event.ProductAction.TotalAmount;
                 gtagProperties.transaction_id = event.ProductAction.TransactionId;

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -18,7 +18,13 @@ var commerceHandler = {
             }
 
             var eventMapping = common.getEventMapping(event);
-            if (eventMapping && eventMapping.result && eventMapping.match) {
+
+            if (!eventMapping) {
+                console.log('Event not mapped. Event not sent.');
+                return false;
+            }
+
+            if (eventMapping.result && eventMapping.match) {
                 var gtagProperties = {};
                 common.setCustomVariables(event, gtagProperties);
                 common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
@@ -32,9 +38,6 @@ var commerceHandler = {
                 }
                 common.sendGtag('purchase', gtagProperties);
                 return true;
-            } else {
-                console.log('Event not mapped. Event not sent.');
-                return false;
             }
         }
     }

--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -1,37 +1,36 @@
 var common = require('./common'),
-    TRANSACTIONS = 'transactions',
+    salesCounterTypes = {
+        transactions: 1,
+        items_sold: 1
+    },
     ITEMS_SOLD = 'items_sold';
 
 var commerceHandler = {
     logCommerceEvent: function(event) {
         if (event.EventDataType === mParticle.CommerceEventType.ProductPurchase) {
+            var counter = event.CustomFlags['DoubleClick.Counter'];
+            if (!counter) {
+                console.log('Event not sent. Sales conversions requires a custom flag of DoubleClick.Counter equal to \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                return;
+            } else if (!salesCounterTypes[counter]) {
+                console.log('Counter type not valid. For sales conversions, use a custom flag of DoubleClick.Counter equal to \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                return;
+            }
+
             var eventMapping = common.getEventMapping(event);
             if (eventMapping && eventMapping.result && eventMapping.match) {
                 var gtagProperties = {};
                 common.setCustomVariables(event, gtagProperties);
                 common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
-                if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
-                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
-                    //stringify number
-                    gtagProperties.value = '' + event.ProductAction.TotalAmount;
-                    gtagProperties.transaction_id = event.ProductAction.TransactionId;
+                gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                //stringify number
+                gtagProperties.value = '' + event.ProductAction.TotalAmount;
+                gtagProperties.transaction_id = event.ProductAction.TransactionId;
 
-                    if (event.CustomFlags['DoubleClick.Counter'] === TRANSACTIONS) {
-                        common.sendGtag('purchase', gtagProperties);
-                    } else if (event.CustomFlags['DoubleClick.Counter'] === ITEMS_SOLD) {
-                        //stringify number
-                        gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
-
-                        common.sendGtag('purchase', gtagProperties);
-                    } else {
-                        console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                        return false;
-                    }
-                } else {
-                    console.log('Counter type not valid. For sales conversions, use \'transactions\', or \'items_sold\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                    return false;
+                if (counter === ITEMS_SOLD) {
+                    gtagProperties.quantity = '' + event.ProductAction.ProductList.length;
                 }
-                common.gtag('event', 'purchase', gtagProperties);
+                common.sendGtag('purchase', gtagProperties);
             } else {
                 console.log('Event not mapped. Event not sent.');
                 return false;

--- a/src/common.js
+++ b/src/common.js
@@ -21,7 +21,7 @@ module.exports = {
     },
     sendGtag: function(type, properties, isInitialization) {
         if (Array.isArray(window.dataLayer)) {
-            if (initialization) {
+            if (isInitialization) {
                 window.dataLayer.push([type, properties]);
             } else {
                 window.dataLayer.push(['event', type, properties]);

--- a/src/common.js
+++ b/src/common.js
@@ -20,7 +20,9 @@ module.exports = {
         return findValueInMapping(jsHash, this.eventMapping);
     },
     sendGtag: function(type, properties) {
-        window.gtag('event', type, properties);
+        if (Array.isArray(window.dataLayer)) {
+            window.dataLayer.push(['event', type, properties]);
+        }
     }
 };
 

--- a/src/common.js
+++ b/src/common.js
@@ -19,9 +19,13 @@ module.exports = {
         var jsHash = calculateJSHash(event.EventDataType, event.EventCategory, event.EventName);
         return findValueInMapping(jsHash, this.eventMapping);
     },
-    sendGtag: function(type, properties) {
+    sendGtag: function(type, properties, isInitialization) {
         if (Array.isArray(window.dataLayer)) {
-            window.dataLayer.push(['event', type, properties]);
+            if (initialization) {
+                window.dataLayer.push([type, properties]);
+            } else {
+                window.dataLayer.push(['event', type, properties]);
+            }
         }
     }
 };

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,56 @@
+module.exports = {
+    eventMapping: {},
+    customVariablesMappings: {},
+    settings: {},
+    setCustomVariables: function(event, gtagProperties) {
+        for (var attribute in event.EventAttributes) {
+            if (this.customVariablesMappings[attribute]) {
+                gtagProperties[this.customVariablesMappings[attribute]] = event.EventAttributes[attribute];
+            }
+        }
+    },
+    setSendTo: function(mapping, customFlags, gtagProperties) {
+        var tags = mapping.value.split(';');
+        var groupTag = tags[0];
+        var activityTag = tags[1];
+        gtagProperties.send_to = 'DC-' + this.settings.advertiserId + '/' + groupTag + '/' + activityTag;
+    },
+    getEventMapping: function (event) {
+        var jsHash = calculateJSHash(event.EventDataType, event.EventCategory, event.EventName);
+        return findValueInMapping(jsHash, this.eventMapping);
+    },
+    sendGtag: function(type, properties) {
+        window.gtag('event', type, properties);
+    }
+};
+
+function findValueInMapping(jsHash, mapping) {
+    if (mapping) {
+        var filteredArray = mapping.filter(function(mappingEntry) {
+            if (mappingEntry.jsmap && mappingEntry.maptype && mappingEntry.value) {
+                return mappingEntry.jsmap === jsHash.toString();
+            }
+
+            return {
+                result: false
+            };
+        });
+
+        if (filteredArray && filteredArray.length > 0) {
+            return {
+                result: true,
+                match: filteredArray[0]
+            };
+        }
+    }
+    return null;
+}
+
+function calculateJSHash(eventDataType, eventCategory, name) {
+    var preHash =
+        ('' + eventDataType) +
+        ('' + eventCategory) + '' +
+        (name || '');
+
+    return mParticle.generateHash(preHash);
+}

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -11,23 +11,29 @@ var eventHandler = {
         var gtagProperties = {};
         common.setCustomVariables(event, gtagProperties);
         var eventMapping = common.getEventMapping(event);
-        if (eventMapping && eventMapping.result && eventMapping.match) {
-            if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
-                if (eventCounterTypes[event.CustomFlags['DoubleClick.Counter']]) {
-                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
-                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
-                    common.sendGtag('conversion', gtagProperties);
-                } else {
-                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                }
-            } else {
-                console.log('event not sent, no counter set. Please set a customFlag of DoubleClick.Counter');
-                return false;
-            }
-        } else {
+
+        if (!eventMapping) {
             console.log('Event not mapped. Event not sent.');
             return false;
         }
+
+        if (eventMapping.result && eventMapping.match) {
+            var counter = event.CustomFlags && event.CustomFlags['DoubleClick.Counter'] ? event.CustomFlags['DoubleClick.Counter'] : null;
+            if (counter) {
+                if (eventCounterTypes[counter]) {
+                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                    gtagProperties.send_to += ('+' + counter);
+                    common.sendGtag('conversion', gtagProperties);
+                } else {
+                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                    return false;
+                }
+            } else {
+                console.log('Event not sent. Event conversions requires a custom flag of DoubleClick.Counter equal to \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                return false;
+            }
+        }
+        return true;
     },
     logError: function() {
     },

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -19,17 +19,16 @@ var eventHandler = {
 
         if (eventMapping.result && eventMapping.match) {
             var counter = event.CustomFlags && event.CustomFlags['DoubleClick.Counter'] ? event.CustomFlags['DoubleClick.Counter'] : null;
-            if (counter) {
-                if (eventCounterTypes[counter]) {
-                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
-                    gtagProperties.send_to += ('+' + counter);
-                    common.sendGtag('conversion', gtagProperties);
-                } else {
-                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
-                    return false;
-                }
-            } else {
+            if (!counter) {
                 console.log('Event not sent. Event conversions requires a custom flag of DoubleClick.Counter equal to \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                return false;
+            }
+            if (eventCounterTypes[counter]) {
+                common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                gtagProperties.send_to += ('+' + counter);
+                common.sendGtag('conversion', gtagProperties);
+            } else {
+                console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
                 return false;
             }
         }

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -1,35 +1,37 @@
-/*
-A non-ecommerce event has the following schema:
+var common = require('./common');
 
-{
-    DeviceId: "a80eea1c-57f5-4f84-815e-06fe971b6ef2",
-    EventAttributes: {test: "Error", t: 'stack trace in string form'},
-    EventName: "Error",
-    MPID: "123123123123",
-    UserAttributes: {userAttr1: 'value1', userAttr2: 'value2'},
-    UserIdentities: [{Identity: 'email@gmail.com', Type: 7}]
-    User Identity Types can be found here:
-}
-
-*/
+var eventCounterTypes = {
+    standard: 1,
+    unique: 1,
+    per_session: 1
+};
 
 var eventHandler = {
     logEvent: function(event) {
-
-    },
-    logError: function(event) {
-        // The schema for a logError event is the same, but noteworthy differences are as follows:
-        // {
-        //     EventAttributes: {m: 'name of error passed into MP', s: "Error", t: 'stack trace in string form if applicable'},
-        //     EventName: "Error"
-        // }
-    },
-    logPageView: function(event) {
-        /* The schema for a logPagView event is the same, but noteworthy differences are as follows:
-        {
-            EventAttributes: {hostname: "www.google.com", title: 'Test Page'},  // These are event attributes only if no additional event attributes are explicitly provided to mParticle.logPageView(...)
+        var gtagProperties = {};
+        common.setCustomVariables(event, gtagProperties);
+        var eventMapping = common.getEventMapping(event);
+        if (eventMapping && eventMapping.result && eventMapping.match) {
+            if (event.CustomFlags && event.CustomFlags['DoubleClick.Counter']) {
+                if (eventCounterTypes[event.CustomFlags['DoubleClick.Counter']]) {
+                    common.setSendTo(eventMapping.match, event.CustomFlags, gtagProperties);
+                    gtagProperties.send_to += ('+' + event.CustomFlags['DoubleClick.Counter']);
+                    common.sendGtag('conversion', gtagProperties);
+                } else {
+                    console.log('Counter type not valid. For event conversions, use \'standard\', \'unique\, or \'per_session\'. See https://support.google.com/dcm/partner/answer/2823400?hl=en for more info')
+                }
+            } else {
+                console.log('event not sent, no counter set. Please set a customFlag of DoubleClick.Counter');
+                return false;
+            }
+        } else {
+            console.log('Event not mapped. Event not sent.');
+            return false;
         }
-        */
+    },
+    logError: function() {
+    },
+    logPageView: function() {
     }
 };
 

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -4,9 +4,6 @@ var initialization = {
     name: 'DoubleclickDFP',
     initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
         common.settings = settings;
-        window.gtag = function() {
-            window.dataLayer.push(arguments);
-        };
 
         window.dataLayer = window.dataLayer || [];
         if (!testMode) {

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -1,42 +1,53 @@
+var common = require('./common');
+
 var initialization = {
-    name: 'insertSDKNameHere',
-/*  ****** Fill out initForwarder to load your SDK ******
-    Note that not all arguments may apply to your SDK initialization.
-    These are passed from mParticle, but leave them even if they are not being used.
-    forwarderSettings contain settings that your SDK requires in order to initialize
-    userAttributes example: {gender: 'male', age: 25}
-    userIdentities example: { 1: 'customerId', 2: 'facebookId', 7: 'emailid@email.com' }
-    additional identityTypes can be found at https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
-*/
+    name: 'DoubleclickDFP',
     initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
-        /* `settings` contains your SDK specific settings such as apiKey that your customer needs in order to initialize your SDK properly */
+        common.settings = settings;
+        window.gtag = function() {
+            window.dataLayer.push(arguments);
+        };
 
+        window.dataLayer = window.dataLayer || [];
         if (!testMode) {
-            /* Load your Web SDK here using a variant of your snippet from your readme that your customers would generally put into their <head> tags
-               Generally, our integrations create script tags and append them to the <head>. Please follow the following format as a guide:
-            */
+            var url = 'https://www.googletagmanager.com/gtag/js?id=' + settings.advertiserId;
 
-            // var clientScript = document.createElement('script');
-            // clientScript.type = 'text/javascript';
-            // clientScript.async = true;
-            // clientScript.src = 'https://www.clientscript.com/static/clientSDK.js';   // <---- Update this to be your script
-            // (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(clientScript);
-            // clientScript.onload = function() {
-            //     if (clientSDKObject && eventQueue.length > 0) {
-            //         // Process any events that may have been queued up while forwarder was being initialized.
-            //         for (var i = 0; i < eventQueue.length; i++) {
-            //             processEvent(eventQueue[i]);
-            //         }
-            //          // now that each queued event is processed, we empty the eventQueue
-            //         eventQueue = [];
-            //     }
-            //    clientSDKObject.initialize(forwarderSettings.apiKey);
-            // };
+            var gTagScript = document.createElement('script');
+            gTagScript.type = 'text/javascript';
+            gTagScript.async = true;
+            gTagScript.src = url;
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(gTagScript);
+            gTagScript.onload = function() {
+                isInitialized = true;
+
+                initializeGoogleDFP(settings);
+
+                if (window.gtag && eventQueue.length > 0) {
+                    // Process any events that may have been queued up while forwarder was being initialized.
+                    for (var i = 0; i < eventQueue.length; i++) {
+                        processEvent(eventQueue[i]);
+                    }
+                     // now that each queued event is processed, we empty the eventQueue
+                    eventQueue = [];
+                }
+            };
         } else {
-            // For testing, you should fill out this section in order to ensure any required initialization calls are made,
-            // clientSDKObject.initialize(forwarderSettings.apiKey)
+            isInitialized = true;
+            initializeGoogleDFP(settings);
         }
     }
 };
+
+function initializeGoogleDFP(settings) {
+    common.eventMapping = JSON.parse(settings.eventMapping.replace(/&quot;/g, '\"'));
+
+    common.customVariablesMappings = JSON.parse(settings.customVariables.replace(/&quot;/g, '\"')).reduce(function(a, b) {
+        a[b.map] = b.value;
+        return a;
+    }, {});
+    window.gtag('js', new Date());
+    window.gtag('allow_custom_scripts', true);
+    window.gtag('config', settings.advertiserId);
+}
 
 module.exports = initialization;

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -19,7 +19,7 @@ var initialization = {
 
                 initializeGoogleDFP(settings);
 
-                if (window.gtag && eventQueue.length > 0) {
+                if (eventQueue.length > 0) {
                     // Process any events that may have been queued up while forwarder was being initialized.
                     for (var i = 0; i < eventQueue.length; i++) {
                         processEvent(eventQueue[i]);
@@ -29,22 +29,22 @@ var initialization = {
                 }
             };
         } else {
-            isInitialized = true;
-            initializeGoogleDFP(settings);
+            initializeGoogleDFP(settings, isInitialized);
         }
     }
 };
 
-function initializeGoogleDFP(settings) {
+function initializeGoogleDFP(settings, isInitialized) {
     common.eventMapping = JSON.parse(settings.eventMapping.replace(/&quot;/g, '\"'));
 
     common.customVariablesMappings = JSON.parse(settings.customVariables.replace(/&quot;/g, '\"')).reduce(function(a, b) {
         a[b.map] = b.value;
         return a;
     }, {});
-    window.gtag('js', new Date());
-    window.gtag('allow_custom_scripts', true);
-    window.gtag('config', settings.advertiserId);
+    common.sendGtag('js', new Date(), true);
+    common.sendGtag('allow_custom_scripts', true, true);
+    common.sendGtag('config', settings.advertiserId, true);
+    isInitialized = true;
 }
 
 module.exports = initialization;

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 
     </script>
     <!-- change name of XYZ-Kit below to the name of your built kit-->
-    <script src="../build/XYZ-Kit.js"></script>
+    <script src="../build/DoubleClick-Kit.js"></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef*/
-describe('XYZ Forwarder', function () {
+describe('DoubleClick', function () {
     // -------------------DO NOT EDIT ANYTHING BELOW THIS LINE-----------------------
     var MessageTypes = {
             SessionStart: 1,
@@ -11,6 +11,21 @@ describe('XYZ Forwarder', function () {
             AppStateTransition: 10,
             Profile: 14,
             Commerce: 16
+        },
+        CommerceEventType = {
+            ProductAddToCart: 10,
+            ProductRemoveFromCart: 11,
+            ProductCheckout: 12,
+            ProductCheckoutOption: 13,
+            ProductClick: 14,
+            ProductViewDetail: 15,
+            ProductPurchase: 16,
+            ProductRefund: 17,
+            PromotionView: 18,
+            PromotionClick: 19,
+            ProductAddToWishlist: 20,
+            ProductRemoveFromWishlist: 21,
+            ProductImpression: 22
         },
         ReportingService = function () {
             var self = this;
@@ -32,22 +47,9 @@ describe('XYZ Forwarder', function () {
 
 // -------------------DO NOT EDIT ANYTHING ABOVE THIS LINE-----------------------
 // -------------------START EDITING BELOW:-----------------------
-// -------------------mParticle stubs - Add any additional stubbing to our methods as needed-----------------------
-    mParticle.Identity = {
-        getCurrentUser: function() {
-            return {
-                getMPID: function() {
-                    return '123';
-                }
-
-            };
-        }
-    };
-// -------------------START EDITING BELOW:-----------------------
-    var MockXYZForwarder = function() {
+    var DoubleClickMockForwarder = function() {
         var self = this;
 
-        // create properties for each type of event you want tracked, see below for examples
         this.trackCustomEventCalled = false;
         this.logPurchaseEventCalled = false;
         this.initializeCalled = false;
@@ -68,14 +70,6 @@ describe('XYZ Forwarder', function () {
             self.initializeCalled = true;
             self.apiKey = apiKey;
             self.appId = appId;
-        };
-
-        this.stubbedTrackingMethod = function(name, eventProperties){
-            self.trackCustomEventCalled = true;
-            self.trackCustomName = name;
-            self.eventProperties.push(eventProperties);
-            // Return true to indicate event should be reported
-            return true;
         };
 
         this.stubbedUserAttributeSettingMethod = function(userAttributes) {
@@ -100,22 +94,18 @@ describe('XYZ Forwarder', function () {
 
     before(function () {
         mParticle.init('test');
-        mParticle.EventType = EventType;
-        mParticle.ProductActionType = ProductActionType;
-        mParticle.PromotionType = PromotionActionType;
-        mParticle.IdentityType = IdentityType;
         mParticle.CommerceEventType = CommerceEventType;
-        mParticle.eCommerce = {};
-        mParticle.eCommerce.expandCommerceEvent = expandCommerceEvent;
+
+        window.mParticle.isTestEnvironment = true;
     });
 
     beforeEach(function() {
-        window.MockXYZForwarder = new MockXYZForwarder();
+        window.DoubleClickMockForwarder = new DoubleClickMockForwarder();
         // Include any specific settings that is required for initializing your SDK here
         var sdkSettings = {
-            clientKey: '123456',
-            appId: 'abcde',
-            userIdField: 'customerId'
+            advertiserId: '123456',
+            customVariables: '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Total Amount&quot;,&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;u1&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;color&quot;,&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;u2&quot;}]',
+            eventMapping: '[{&quot;jsmap&quot;:&quot;-1978027768&quot;,&quot;map&quot;:&quot;-1711833867978608722&quot;,&quot;maptype&quot;:&quot;EventClass.Id&quot;,&quot;value&quot;:&quot;group tag2;activity tag2&quot;},{&quot;jsmap&quot;:&quot;-1107730368&quot;,&quot;map&quot;:&quot;-3234618101041058100&quot;,&quot;maptype&quot;:&quot;EventClass.Id&quot;,&quot;value&quot;:&quot;group tag3;activity tag3&quot;},{&quot;jsmap&quot;:&quot;-1592184962&quot;,&quot;map&quot;:&quot;-4153695833896571372&quot;,&quot;maptype&quot;:&quot;EventClassDetails.Id&quot;,&quot;value&quot;:&quot;group tag4;activity tag4&quot;}]'
         };
         // You may require userAttributes or userIdentities to be passed into initialization
         var userAttributes = {
@@ -123,120 +113,225 @@ describe('XYZ Forwarder', function () {
         };
         var userIdentities = [{
             Identity: 'customerId',
-            Type: IdentityType.CustomerId
+            Type: mParticle.IdentityType.CustomerId
         }, {
             Identity: 'email',
-            Type: IdentityType.Email
+            Type: mParticle.IdentityType.Email
         }, {
             Identity: 'facebook',
-            Type: IdentityType.Facebook
+            Type: mParticle.IdentityType.Facebook
         }];
+
         mParticle.forwarder.init(sdkSettings, reportService.cb, true, null, userAttributes, userIdentities);
     });
 
-    it('should log event', function(done) {
-        // mParticle.forwarder.process({
-        //     EventDataType: MessageType.PageEvent,
-        //     EventName: 'Test Event',
-        //     EventAttributes: {
-        //         label: 'label',
-        //         value: 200,
-        //         category: 'category'
-        //     }
-        // });
-        //
-        // window.MockXYZForwarder.eventProperties[0].label.should.equal('label');
-        // window.MockXYZForwarder.eventProperties[0].value.should.equal(200);
+    it('should initialize properly', function(done) {
+        window.dataLayer[0][0].should.equal('js');
+        (typeof window.dataLayer[0][1]).should.equal('object');
+
+        window.dataLayer[1][0].should.equal('allow_custom_scripts');
+        window.dataLayer[1][1].should.equal(true);
+        window.dataLayer[2][0].should.equal('config');
+        window.dataLayer[2][1].should.equal('123456');
+
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            CustomFlags: {
+                'DoubleClick.Counter': 'unique'
+            }
+        });
+        window.dataLayer[0][2].should.have.property('send_to', 'DC-123456/group tag2/activity tag2+unique');
+
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            CustomFlags: {
+                'DoubleClick.Counter': 'per_session'
+            }
+        });
+        window.dataLayer[0][0].should.equal('event');
+        window.dataLayer[0][1].should.equal('conversion');
+        window.dataLayer[0][2].should.have.property('send_to', 'DC-123456/group tag2/activity tag2+per_session');
 
         done();
     });
 
-    it('should log page view', function(done) {
-        // mParticle.forwarder.process({
-        //     EventDataType: MessageType.PageView,
-        //     EventName: 'test name',
-        //     EventAttributes: {
-        //         attr1: 'test1',
-        //         attr2: 'test2'
-        //     }
-        // });
-        //
-        // window.MockXYZForwarder.trackCustomEventCalled.should.equal(true);
-        // window.MockXYZForwarder.trackCustomName.should.equal('test name');
-        // window.MockXYZForwarder.eventProperties[0].attr1.should.equal('test1');
-        // window.MockXYZForwarder.eventProperties[0].attr2.should.equal('test2');
+    it('should log event that has the appropriate custom flags', function(done) {
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            EventAttributes: {
+                'Total Amount': 123,
+                color: 'blue'
+            },
+            CustomFlags: {
+                'DoubleClick.Counter': 'standard'
+            }
+        });
+        window.dataLayer[0][0].should.equal('event');
+        window.dataLayer[0][1].should.equal('conversion');
+        window.dataLayer[0][2].should.have.property('u1', 123);
+        window.dataLayer[0][2].should.have.property('u2', 'blue');
+        window.dataLayer[0][2].should.have.property('send_to', 'DC-123456/group tag2/activity tag2+standard');
+
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            CustomFlags: {
+                'DoubleClick.Counter': 'unique'
+            }
+        });
+        window.dataLayer[0][2].should.have.property('send_to', 'DC-123456/group tag2/activity tag2+unique');
+
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            CustomFlags: {
+                'DoubleClick.Counter': 'per_session'
+            }
+        });
+        window.dataLayer[0][0].should.equal('event');
+        window.dataLayer[0][1].should.equal('conversion');
+        window.dataLayer[0][2].should.have.property('send_to', 'DC-123456/group tag2/activity tag2+per_session');
 
         done();
     });
 
-    it('should log a product purchase commerce event', function(done) {
-        // mParticle.forwarder.process({
-        //     EventName: 'Test Purchase Event',
-        //     EventDataType: MessageType.Commerce,
-        //     EventCategory: EventType.ProductPurchase,
-        //     ProductAction: {
-        //         ProductActionType: ProductActionType.Purchase,
-        //         ProductList: [
-        //             {
-        //                 Sku: '12345',
-        //                 Name: 'iPhone 6',
-        //                 Category: 'Phones',
-        //                 Brand: 'iPhone',
-        //                 Variant: '6',
-        //                 Price: 400,
-        //                 TotalAmount: 400,
-        //                 CouponCode: 'coupon-code',
-        //                 Quantity: 1
-        //             }
-        //         ],
-        //         TransactionId: 123,
-        //         Affiliation: 'my-affiliation',
-        //         TotalAmount: 450,
-        //         TaxAmount: 40,
-        //         ShippingAmount: 10,
-        //         CouponCode: null
-        //     }
-        // });
-        //
-        // window.MockXYZForwarder.trackCustomEventCalled.should.equal(true);
-        // window.MockXYZForwarder.trackCustomName.should.equal('Purchase');
-        //
-        // window.MockXYZForwarder.eventProperties[0].Sku.should.equal('12345');
-        // window.MockXYZForwarder.eventProperties[0].Name.should.equal('iPhone 6');
-        // window.MockXYZForwarder.eventProperties[0].Category.should.equal('Phones');
-        // window.MockXYZForwarder.eventProperties[0].Brand.should.equal('iPhone');
-        // window.MockXYZForwarder.eventProperties[0].Variant.should.equal('6');
-        // window.MockXYZForwarder.eventProperties[0].Price.should.equal(400);
-        // window.MockXYZForwarder.eventProperties[0].TotalAmount.should.equal(400);
-        // window.MockXYZForwarder.eventProperties[0].CouponCode.should.equal('coupon-code');
-        // window.MockXYZForwarder.eventProperties[0].Quantity.should.equal(1);
+    it('should not log an event that has no custom flag, or an incorrect custom flag', function(done) {
+        window.dataLayer = [];
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event'
+        });
+
+        mParticle.forwarder.process({
+            EventDataType: MessageTypes.PageEvent,
+            EventCategory: mParticle.EventType.Unknown,
+            EventName: 'Test Event',
+            CustomFlags: {
+                'DoubleClick.Counter': 'invalidCounter'
+            }
+        });
+
+        window.dataLayer.length.should.equal(0);
 
         done();
     });
 
-    it('should set customer id user identity on user identity change', function(done) {
-        // var fakeUserStub = {
-        //     getUserIdentities: function() {
-        //         return {
-        //             userIdentities: {
-        //                 customerid: '123'
-        //             }
-        //         };
-        //     },
-        //     getMPID: function() {
-        //         return 'testMPID';
-        //     },
-        //     setUserAttribute: function() {
-        //
-        //     },
-        //     removeUserAttribute: function() {
-        //
-        //     }
-        // };
-        //
-        // mParticle.forwarder.onUserIdentified(fakeUserStub);
-        //
-        // window.MockXYZForwarder.userId.should.equal('123');
+    it('should log a product purchase commerce event with custom flag of transactions', function(done) {
+        window.dataLayer = [];
+
+        mParticle.forwarder.process({
+            EventName: 'eCommerce - Purchase',
+            EventDataType: MessageTypes.Commerce,
+            EventCategory: mParticle.CommerceEventType.ProductPurchase,
+            ProductAction: {
+                ProductActionType: mParticle.ProductActionType.Purchase,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    },
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    }
+                ],
+                TransactionId: 'tid123',
+                Affiliation: 'my-affiliation',
+                TotalAmount: 850,
+                TaxAmount: 40,
+                ShippingAmount: 10,
+                CouponCode: null
+            },
+            CustomFlags: {
+                'DoubleClick.Counter': 'transactions'
+            }
+        });
+        window.dataLayer[0][0].should.equal('event');
+        window.dataLayer[0][1].should.equal('purchase');
+        window.dataLayer[0][2].should.have.property('value', '850');
+        window.dataLayer[0][2].should.have.property('transaction_id', 'tid123');
+        window.dataLayer[0][2].should.not.have.property('quantity');
+
+        done();
+    });
+
+    it('should log a product purchase commerce event with custom flag of items_sold', function(done) {
+        window.dataLayer = [];
+
+        mParticle.forwarder.process({
+            EventName: 'eCommerce - Purchase',
+            EventDataType: MessageTypes.Commerce,
+            EventCategory: mParticle.CommerceEventType.ProductPurchase,
+            ProductAction: {
+                ProductActionType: mParticle.ProductActionType.Purchase,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    },
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    }
+                ],
+                TransactionId: 'tid123',
+                Affiliation: 'my-affiliation',
+                TotalAmount: 850,
+                TaxAmount: 40,
+                ShippingAmount: 10,
+                CouponCode: null
+            },
+            CustomFlags: {
+                'DoubleClick.Counter': 'items_sold'
+            }
+        });
+        window.dataLayer[0][0].should.equal('event');
+        window.dataLayer[0][1].should.equal('purchase');
+        window.dataLayer[0][2].should.have.property('value', '850');
+        window.dataLayer[0][2].should.have.property('transaction_id', 'tid123');
+        window.dataLayer[0][2].should.have.property('quantity', '2');
 
         done();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -210,6 +210,7 @@ describe('DoubleClick', function () {
 
     it('should not log an event that has no custom flag, or an incorrect custom flag', function(done) {
         window.dataLayer = [];
+
         mParticle.forwarder.process({
             EventDataType: MessageTypes.PageEvent,
             EventCategory: mParticle.EventType.Unknown,
@@ -332,6 +333,95 @@ describe('DoubleClick', function () {
         window.dataLayer[0][2].should.have.property('value', '850');
         window.dataLayer[0][2].should.have.property('transaction_id', 'tid123');
         window.dataLayer[0][2].should.have.property('quantity', '2');
+
+        done();
+    });
+
+    it('should not log a product purchase commerce event without a custom flag or with an incorrect custom flag', function(done) {
+        window.dataLayer = [];
+
+        mParticle.forwarder.process({
+            EventName: 'eCommerce - Purchase',
+            EventDataType: MessageTypes.Commerce,
+            EventCategory: mParticle.CommerceEventType.ProductPurchase,
+            ProductAction: {
+                ProductActionType: mParticle.ProductActionType.Purchase,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    },
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    }
+                ],
+                TransactionId: 'tid123',
+                Affiliation: 'my-affiliation',
+                TotalAmount: 850,
+                TaxAmount: 40,
+                ShippingAmount: 10,
+                CouponCode: null
+            },
+            CustomFlags: {
+                'DoubleClick.Counter': 'invalidCounter'
+            }
+        });
+
+        mParticle.forwarder.process({
+            EventName: 'eCommerce - Purchase',
+            EventDataType: MessageTypes.Commerce,
+            EventCategory: mParticle.CommerceEventType.ProductPurchase,
+            ProductAction: {
+                ProductActionType: mParticle.ProductActionType.Purchase,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    },
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    }
+                ],
+                TransactionId: 'tid123',
+                Affiliation: 'my-affiliation',
+                TotalAmount: 850,
+                TaxAmount: 40,
+                ShippingAmount: 10,
+                CouponCode: null
+            }
+        });
+
+        window.dataLayer.length.should.equal(0);
 
         done();
     });


### PR DESCRIPTION
Starbucks Doubleclick web integration is ready for review! I cleaned up the commits to make reviewing much easier.

A few notes:
* There are a few legacy ways of implementing "Floodlight conversion" which is what DFP/DFA is all about (ie. via image tag, via iframes). However, Google is moving towards a global `gtag` for all its products, XHR requests. Our web integration is implemented via the gtag method in order to be more future proof.
* The main doc I used was here: https://support.google.com/dcm/answer/7554821#fields.
* Above they have a lot of examples for the 2 types of events they support, conversion events and sales events, which I mimicked.
* The doc shows that you can also add a <noscript> tag for browsers with JS disabled or that don't have JS.  This is on the HTML page, so I don't think this is necessary (since if there is no JS, then we don't work anyhow).