### PR TITLE
Upgrade web-kit-wrapper version, rollup.config.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,8 @@
       }
     },
     "@mparticle/web-kit-wrapper": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@mparticle/web-kit-wrapper/-/web-kit-wrapper-1.0.4.tgz",
-      "integrity": "sha512-jywqHNHtrdVEf39zsKi/FVNvhQJnM6K5Idlx5mQlsxGfENLUkOSoFrvaWIPz05XKU17pahcnCVfjgHSFj/etOA==",
+      "version": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#7a2eb9684d3be2480596303d1ac7e5ec63a3a0cd",
+      "from": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#bugfix/node-env",
       "requires": {
         "express": "^4.16.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,9 @@
       }
     },
     "@mparticle/web-kit-wrapper": {
-      "version": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#7a2eb9684d3be2480596303d1ac7e5ec63a3a0cd",
-      "from": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#bugfix/node-env",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mparticle/web-kit-wrapper/-/web-kit-wrapper-1.0.5.tgz",
+      "integrity": "sha512-keAK+DFjwUSW9Jh7hixcOaZF/m8GDPj/uLCcbWq2x8LaKoqFiaGsz4KXGS2oMmSQib698GCSujstPXzqGKvHeg==",
       "requires": {
         "express": "^4.16.4"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-kit-wrapper": "^1.0.0-rc7"
+        "@mparticle/web-kit-wrapper": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#bugfix/node-env"
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-kit-wrapper": "git://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper.git#bugfix/node-env"
+        "@mparticle/web-kit-wrapper": "^1.0.5"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,34 +1,34 @@
-import base from './node_modules/@mparticle/web-kit-wrapper/rollup.base';
+import { production } from './node_modules/@mparticle/web-kit-wrapper/rollup.base';
 
 export default [
     {
-        input: base.input,
+        input: production.input,
         output: {
-            ...base.output,
+            ...production.output,
             format: 'iife',
             file: 'build/DoubleClick-Kit.js',
             name: 'mpDoubleClickKit',
         },
-        plugins: [...base.plugins]
+        plugins: [...production.plugins]
     },
     {
-        input: base.input,
+        input: production.input,
         output: {
-            ...base.output,
+            ...production.output,
             format: 'iife',
             file: 'dist/DoubleClick-Kit.iife.js',
             name: 'mpDoubleClickKit',
         },
-        plugins: [...base.plugins]
+        plugins: [...production.plugins]
     },
     {
-        input: base.input,
+        input: production.input,
         output: {
-            ...base.output,
+            ...production.output,
             format: 'cjs',
             file: 'dist/DoubleClick-Kit.common.js',
             name: 'mpDoubleClickKit',
         },
-        plugins: [...base.plugins]
+        plugins: [...production.plugins]
     }
 ];


### PR DESCRIPTION
The previous version of web-kit-wrapper that doubleclick kit was on only exported a single `base` rollup config. This has been replaced with a [production](https://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper/commit/f58884a2a6add5e678338bee930f764b8c3d239e#diff-e303c20b1561351077879f8bfad4137c87421a38a9b5de1bf884a71d8c91707bR4-R30) config that the kits now consume.

