### PR TITLE
feat: Add Consent Support to Doubleclick Kit

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,11 @@
-function Common() {}
+var ConsentHandler = require('./consent');
+function Common() {
+    this.consentMappings = [];
+    this.consentPayloadDefaults = {};
+    this.consentPayloadAsString = '';
+
+    this.consentHandler = new ConsentHandler(this);
+}
 
 Common.prototype.eventMapping = {};
 Common.prototype.customVariablesMappings = {};
@@ -37,6 +44,21 @@ Common.prototype.sendGtag = function(type, properties, isInitialization) {
             gtag('event', type, properties);
         }
     }
+};
+
+Common.prototype.sendGtagConsent = function (type, payload) {
+    function gtag() {
+        window.dataLayer.push(arguments);
+    }
+    gtag('consent', type, payload);
+};
+
+Common.prototype.cloneObject = function (obj) {
+    return JSON.parse(JSON.stringify(obj));
+};
+
+Common.prototype.isEmpty = function isEmpty(value) {
+    return value == null || !(Object.keys(value) || value).length;
 };
 
 module.exports = Common;

--- a/src/consent.js
+++ b/src/consent.js
@@ -1,0 +1,110 @@
+var googleConsentValues = {
+    // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
+    // However, this is not used by Google's Web SDK. We are referencing it here as a comment
+    // as a record of this distinction and for posterity.
+    // If Google ever adds this for web, the line can just be uncommented to support this.
+    //
+    // Docs:
+    // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
+    // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
+    //
+    // Unspecified: 'unspecified',
+    Denied: 'denied',
+    Granted: 'granted',
+};
+
+// Declares list of valid Google Consent Properties
+var googleConsentProperties = [
+    'ad_storage',
+    'ad_user_data',
+    'ad_personalization',
+    'analytics_storage',
+];
+
+function ConsentHandler(common) {
+    this.common = common || {};
+}
+
+ConsentHandler.prototype.getUserConsentState = function () {
+    var userConsentState = {};
+
+    if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
+        var currentUser = mParticle.Identity.getCurrentUser();
+
+        if (!currentUser) {
+            return {};
+        }
+
+        var consentState =
+            mParticle.Identity.getCurrentUser().getConsentState();
+
+        if (consentState && consentState.getGDPRConsentState) {
+            userConsentState = consentState.getGDPRConsentState();
+        }
+    }
+
+    return userConsentState;
+};
+
+ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
+    return eventConsentState && eventConsentState.getGDPRConsentState
+        ? eventConsentState.getGDPRConsentState()
+        : {};
+};
+
+ConsentHandler.prototype.getConsentSettings = function () {
+    var consentSettings = {};
+
+    var googleToMpConsentSettingsMapping = {
+        ad_user_data: 'defaultAdUserDataConsent',
+        ad_personalization: 'defaultAdPersonalizationConsent',
+        ad_storage: 'defaultAdStorageConsentWeb',
+        analytics_storage: 'defaultAnalyticsStorageConsentWeb',
+    };
+
+    var settings = this.common.settings;
+
+    Object.keys(googleToMpConsentSettingsMapping).forEach(function (
+        googleConsentKey
+    ) {
+        var mpConsentSettingKey =
+            googleToMpConsentSettingsMapping[googleConsentKey];
+        var googleConsentValuesKey = settings[mpConsentSettingKey];
+
+        if (googleConsentValuesKey && mpConsentSettingKey) {
+            consentSettings[googleConsentKey] =
+                googleConsentValues[googleConsentValuesKey];
+        }
+    });
+
+    return consentSettings;
+};
+
+ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
+    consentState,
+    mappings
+) {
+    if (!mappings) return {};
+
+    var payload = this.common.cloneObject(this.common.consentPayloadDefaults);
+
+    for (var i = 0; i <= mappings.length - 1; i++) {
+        var mappingEntry = mappings[i];
+        var mpMappedConsentName = mappingEntry.map;
+        var googleMappedConsentName = mappingEntry.value;
+
+        if (
+            consentState[mpMappedConsentName] &&
+            googleConsentProperties.indexOf(googleMappedConsentName) !== -1
+        ) {
+            payload[googleMappedConsentName] = consentState[mpMappedConsentName]
+                .Consented
+                ? googleConsentValues.Granted
+                : googleConsentValues.Denied;
+        }
+    }
+
+    return payload;
+};
+
+module.exports = ConsentHandler;

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -10,7 +10,35 @@ function EventHandler(common) {
     this.common = common || {};
 }
 
-EventHandler.prototype.logEvent = function(event) {
+EventHandler.prototype.maybeSendConsentUpdateToGa4 = function (event) {
+    // If consent payload is empty,
+    // we never sent an initial default consent state
+    // so we shouldn't send an update.
+    if (this.common.consentPayloadAsString && this.common.consentMappings) {
+        var eventConsentState = this.common.consentHandler.getEventConsentState(
+            event.ConsentState
+        );
+
+        if (!this.common.isEmpty(eventConsentState)) {
+            var updatedConsentPayload =
+                this.common.consentHandler.generateConsentStatePayloadFromMappings(
+                    eventConsentState,
+                    this.common.consentMappings
+                );
+
+            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
+
+            if (eventConsentAsString !== this.common.consentPayloadAsString) {
+                this.common.sendGtagConsent('update', updatedConsentPayload);
+                this.common.consentPayloadAsString = eventConsentAsString;
+            }
+        }
+    }
+};
+
+EventHandler.prototype.logEvent = function (event) {
+    this.maybeSendConsentUpdateToGa4(event);
+
     var gtagProperties = {};
     this.common.setCustomVariables(event, gtagProperties);
     var eventMapping = this.common.getEventMapping(event);

--- a/test/tests.js
+++ b/test/tests.js
@@ -10,7 +10,22 @@ describe('DoubleClick', function () {
             OptOut: 6,
             AppStateTransition: 10,
             Profile: 14,
-            Commerce: 16
+            Commerce: 16,
+        },
+        EventType = {
+            Unknown: 0,
+            Navigation: 1,
+            Location: 2,
+            Search: 3,
+            Transaction: 4,
+            UserContent: 5,
+            UserPreference: 6,
+            Social: 7,
+            Other: 8,
+            Media: 9,
+            getName: function () {
+                return 'blahblah';
+            },
         },
         CommerceEventType = {
             ProductAddToCart: 10,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds a check to initForwarder and processEvents so that if the consent state changes, we alert Google via their gtag as per their [Consent Mode Documention](https://developers.google.com/tag-platform/security/guides/consent)

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Set up Consent Mapping and Privacy Configuration via the mParticle UI
 - Using our [Data Privacy Controls] instructions, toggle some of the mapped consent states via the developer console
 - Verify that mapped events appear in window.dataLayer via browser developer console as updates with updated values

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6191
 - Mirrors similar update to https://github.com/mparticle-integrations/mparticle-javascript-integration-adwords/pull/52
