### PR TITLE
fix: Set mapped consent name from server to lowercase

### DIFF
--- a/src/consent.js
+++ b/src/consent.js
@@ -90,7 +90,10 @@ ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
 
     for (var i = 0; i <= mappings.length - 1; i++) {
         var mappingEntry = mappings[i];
-        var mpMappedConsentName = mappingEntry.map;
+        // Although consent purposes can be inputted into the UI in any casing
+        // the SDK will automatically lowercase them to prevent pseudo-duplicate
+        // consent purposes, so we call `toLowerCase` on the consentMapping purposes here
+        var mpMappedConsentName = mappingEntry.map.toLowerCase();
         var googleMappedConsentName = mappingEntry.value;
 
         if (

--- a/test/tests.js
+++ b/test/tests.js
@@ -508,25 +508,25 @@ describe('DoubleClick', function () {
         var consentMap = [
             {
                 jsmap: null,
-                map: 'some_consent',
+                map: 'Some_consent',
                 maptype: 'ConsentPurposes',
                 value: 'ad_user_data',
             },
             {
                 jsmap: null,
-                map: 'storage_consent',
+                map: 'Storage_consent',
                 maptype: 'ConsentPurposes',
                 value: 'analytics_storage',
             },
             {
                 jsmap: null,
-                map: 'other_test_consent',
+                map: 'Other_test_consent',
                 maptype: 'ConsentPurposes',
                 value: 'ad_storage',
             },
             {
                 jsmap: null,
-                map: 'test_consent',
+                map: 'Test_consent',
                 maptype: 'ConsentPurposes',
                 value: 'ad_personalization',
             },
@@ -541,7 +541,7 @@ describe('DoubleClick', function () {
                 {
                     conversionId: 'AW-123123123',
                     consentMappingWeb:
-                        '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                     eventMapping: '[]',
                     customVariables: '[]',
                 },


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
While consent purposes can be inputted into the web sdk via any casing, the SDK will automatically lowercase them to prevent pseudo-duplicate consent purposes.  In the UI, these have a capital first letter, and the server sends them back with a capital first letter also.   To keep it all consistent, we should lowercase what comes back from the server.

I also added this comment in our onetrust kit so that future developers are aware - https://github.com/mparticle-integrations/mparticle-javascript-integration-onetrust/pull/42/commits/754688327dd4a48965568044cdbf7e6c64b84ded#diff-105894ea1c74ee2f835325f6211da57e6a15a8236598d11a9ea6b0e7a8f29b47R87-R93

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Tested on local app. Updated unit tests.  When updating the unit tests with a capital 1st letter, it fails a bunch of tests.  Then when adding `toLowerCase`, tests run properly.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6316