### PR TITLE
ci: Update GHA action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
         needs: confirm-public-repo-master-branch
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: NPM install
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18.x
 
@@ -51,7 +51,7 @@ jobs:
             - confirm-public-repo-master-branch
         steps:
             - name: Checkout development branch
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: mparticle-integrations/mparticle-javascript-integration-doubleclick
                   ref: development
@@ -78,7 +78,7 @@ jobs:
 
         steps:
             - name: Checkout public master branch
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   ref: master
@@ -95,7 +95,7 @@ jobs:
               run: |
                   git pull origin release/${{ github.run_number }}
             - name: Setup Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: latest
 
@@ -129,7 +129,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout master branch
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   repository: ${{ github.repository }}


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Updating checkout and setup-node to v4

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
These changes can't be tested locally but have been done in other repos such as [BingAds](https://github.com/mparticle-integrations/mparticle-javascript-integration-bingads/commit/17a7b15371118e5c8d65c9d0892cb03610d59d10#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7290
