### PR TITLE
fix: Return false for non-purchase events

### DIFF
--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -53,7 +53,11 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
             this.common.sendGtag('purchase', gtagProperties);
             return true;
         }
+
+        return false;
     }
+
+    return false;
 };
 
 module.exports = CommerceHandler;

--- a/test/tests.js
+++ b/test/tests.js
@@ -505,6 +505,42 @@ describe('DoubleClick', function () {
         done();
     });
 
+    it('should return false for non-purchase commerce events', function(done) {
+        window.dataLayer = [];
+
+        var result = mParticle.forwarder.process({
+            EventName: 'eCommerce - AddToCart',
+            EventDataType: MessageTypes.Commerce,
+            EventCategory: mParticle.CommerceEventType.ProductAddToCart,
+            ProductAction: {
+                ProductActionType: mParticle.ProductActionType.AddToCart,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        TotalAmount: 400,
+                        CouponCode: 'coupon-code',
+                        Quantity: 1
+                    }
+                ]
+            },
+            CustomFlags: {
+                'DoubleClick.Counter': 'transactions'
+            }
+        });
+
+        result.should.equal(
+            'Error logging event or event type not supported on forwarder DoubleclickDFP'
+        );
+        window.dataLayer.length.should.equal(0);
+
+        done();
+    });
+
     it('should log event with custom field mappings', function(done) {
         window.dataLayer = [];
         mParticle.forwarder.process({


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Previously non-purchase results returned undefined, which is falsey. This bugfix forces a `false` value.

 ## Testing Plan
 - [] Was this tested locally? If not, explain why.
Added unit test